### PR TITLE
Change autcconfigure detection of libasound presence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,10 +5,10 @@ AM_INIT_AUTOMAKE
 AC_PROG_CC
 
 # Check for the alsa sound library.
-AC_CHECK_LIB(asound, asound)
+AC_CHECK_LIB(asound, snd_pcm_hw_params_any)
 
 AC_CONFIG_FILES([
-   Makefile 
+   Makefile
    src/Makefile
    man/Makefile
 ])


### PR DESCRIPTION
With libasound2-1.2.4-1 on debian bullseye the asound lib isn't detected anymore and linking will fail:
`checking for snd_pcm_hw_params_any in -lasound... no`
Bij changing the search symbol from `asound` to `snd_pcm_hw_params_any` the library is found again:
`checking for snd_pcm_hw_params_any in -lasound... yes`